### PR TITLE
feat: bump flutter sdk to 2.5.1

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,4 +1,4 @@
 {
-  "flutterSdkVersion": "2.2.3",
+  "flutterSdkVersion": "2.5.1",
   "flavors": {}
 }

--- a/.github/workflows/test_deploy_release.yml
+++ b/.github/workflows/test_deploy_release.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
 
 env:
-  flutter-version: 2.2.3
+  flutter-version: 2.5.1
 
 jobs:
   test:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -35,7 +35,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -143,7 +143,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -218,7 +218,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:

--- a/lib/advanced_theme/cubit/advanced_theme_cubit.dart
+++ b/lib/advanced_theme/cubit/advanced_theme_cubit.dart
@@ -3,6 +3,7 @@ import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_theme/common/common.dart';
+import 'package:flutter_theme/models/models.dart';
 import 'package:flutter_theme/services/services.dart';
 import 'package:random_color_scheme/random_color_scheme.dart';
 

--- a/lib/advanced_theme/cubit/advanced_theme_state.dart
+++ b/lib/advanced_theme/cubit/advanced_theme_state.dart
@@ -19,10 +19,4 @@ class AdvancedThemeState extends Equatable {
   }
 
   bool get isPrimaryColorDark => !isPrimaryColorLight;
-
-  bool get isAccentColorLight {
-    return themeData.accentColorBrightness == Brightness.light;
-  }
-
-  bool get isAccentColorDark => !isAccentColorLight;
 }

--- a/lib/advanced_theme/cubit/app_bar_cubit.dart
+++ b/lib/advanced_theme/cubit/app_bar_cubit.dart
@@ -1,31 +1,18 @@
 part of 'advanced_theme_cubit.dart';
 
 extension AppBarCubit on AdvancedThemeCubit {
-  void appBarColorChanged(Color color) {
-    final appBarTheme = state.themeData.appBarTheme.copyWith(color: color);
-    _emitStateWithAppBarTheme(appBarTheme);
+  void appBarBackgroundColorChanged(Color color) {
+    final appBarTheme = state.themeData.appBarTheme.copyWith(
+      backgroundColor: color,
+    );
+    _emitWithAppBarTheme(appBarTheme);
   }
 
-  void appBarShadowColorChanged(Color color) {
+  void appBarForegroundColorChanged(Color color) {
     final appBarTheme = state.themeData.appBarTheme.copyWith(
-      shadowColor: color,
+      foregroundColor: color,
     );
-    _emitStateWithAppBarTheme(appBarTheme);
-  }
-
-  void appBarBrightnessChanged(bool isDark) {
-    final brightness = isDark ? Brightness.dark : Brightness.light;
-    final appBarTheme = state.themeData.appBarTheme.copyWith(
-      brightness: brightness,
-    );
-    _emitStateWithAppBarTheme(appBarTheme);
-  }
-
-  void appBarCenterTitleChanged(bool isCenter) {
-    final appBarTheme = state.themeData.appBarTheme.copyWith(
-      centerTitle: isCenter,
-    );
-    _emitStateWithAppBarTheme(appBarTheme);
+    _emitWithAppBarTheme(appBarTheme);
   }
 
   void appBarElevationChanged(String value) {
@@ -34,8 +21,22 @@ extension AppBarCubit on AdvancedThemeCubit {
       final appBarTheme = state.themeData.appBarTheme.copyWith(
         elevation: elevation,
       );
-      _emitStateWithAppBarTheme(appBarTheme);
+      _emitWithAppBarTheme(appBarTheme);
     }
+  }
+
+  void appBarShadowColorChanged(Color color) {
+    final appBarTheme = state.themeData.appBarTheme.copyWith(
+      shadowColor: color,
+    );
+    _emitWithAppBarTheme(appBarTheme);
+  }
+
+  void appBarCenterTitleChanged(bool isCenter) {
+    final appBarTheme = state.themeData.appBarTheme.copyWith(
+      centerTitle: isCenter,
+    );
+    _emitWithAppBarTheme(appBarTheme);
   }
 
   void appBarTitleSpacingChanged(String value) {
@@ -44,11 +45,33 @@ extension AppBarCubit on AdvancedThemeCubit {
       final appBarTheme = state.themeData.appBarTheme.copyWith(
         titleSpacing: spacing,
       );
-      _emitStateWithAppBarTheme(appBarTheme);
+      _emitWithAppBarTheme(appBarTheme);
     }
   }
 
-  void _emitStateWithAppBarTheme(AppBarTheme appBarTheme) {
+  void appBarToolBarHeightChanged(String value) {
+    final height = double.tryParse(value);
+    if (height != null) {
+      final appBarTheme = state.themeData.appBarTheme.copyWith(
+        toolbarHeight: height,
+      );
+      _emitWithAppBarTheme(appBarTheme);
+    }
+  }
+
+  void appBarSystemUiOverlayStyleChanged(String value) {
+    print(value);
+    final style = MySystemUiOverlayStyle().enumFromString(value);
+    print(style);
+    if (style != null) {
+      final appBarTheme = state.themeData.appBarTheme.copyWith(
+        systemOverlayStyle: style,
+      );
+      _emitWithAppBarTheme(appBarTheme);
+    }
+  }
+
+  void _emitWithAppBarTheme(AppBarTheme appBarTheme) {
     emit(
       state.copyWith(
         themeData: state.themeData.copyWith(appBarTheme: appBarTheme),

--- a/lib/advanced_theme/cubit/color_cubit.dart
+++ b/lib/advanced_theme/cubit/color_cubit.dart
@@ -16,8 +16,6 @@ extension ColorCubit on AdvancedThemeCubit {
           primaryColorBrightness: primaryColorBrightness,
           primaryColorLight: swatch[100],
           primaryColorDark: swatch[700],
-          accentColor: color,
-          accentColorBrightness: primaryColorBrightness,
           backgroundColor: swatch[200],
           indicatorColor: color,
           secondaryHeaderColor: swatch[50],
@@ -65,46 +63,6 @@ extension ColorCubit on AdvancedThemeCubit {
           primaryColorDark: color,
           buttonTheme: buttonTheme,
           colorScheme: colorScheme,
-        ),
-      ),
-    );
-  }
-
-  void accentColorChanged(Color color) {
-    final theme = ThemeData(accentColor: color);
-    final colorScheme = state.themeData.colorScheme.copyWith(
-      secondary: color,
-    );
-    final buttonTheme = state.themeData.buttonTheme.copyWith(
-      colorScheme: colorScheme,
-    );
-
-    emit(
-      state.copyWith(
-        themeData: state.themeData.copyWith(
-          accentColor: color,
-          accentColorBrightness: ThemeData.estimateBrightnessForColor(color),
-          accentIconTheme: theme.accentIconTheme,
-          accentTextTheme: theme.accentTextTheme,
-          buttonTheme: buttonTheme,
-          colorScheme: colorScheme,
-          indicatorColor: color,
-          toggleableActiveColor: color,
-        ),
-      ),
-    );
-  }
-
-  void accentColorBrightnessChanged(bool isDark) {
-    final brightness = isDark ? Brightness.dark : Brightness.light;
-    final theme = ThemeData(accentColorBrightness: brightness);
-
-    emit(
-      state.copyWith(
-        themeData: state.themeData.copyWith(
-          accentColorBrightness: brightness,
-          accentIconTheme: theme.accentIconTheme,
-          accentTextTheme: theme.accentTextTheme,
         ),
       ),
     );

--- a/lib/advanced_theme/views/app_bar/app_bar_editor.dart
+++ b/lib/advanced_theme/views/app_bar/app_bar_editor.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_theme/advanced_theme/advanced_theme.dart';
 import 'package:flutter_theme/common/common.dart';
+import 'package:flutter_theme/models/models.dart';
 import 'package:flutter_theme/widgets/widgets.dart';
 
 class AppBarEditor extends StatelessWidget {
@@ -12,12 +13,14 @@ class AppBarEditor extends StatelessWidget {
       children: [
         SideBySideList(
           children: [
-            _ColorPicker(),
+            _BackgroundColorPicker(),
+            _ForegroundColorPicker(),
             _ShadowColorPicker(),
-            _BrightnessSwitch(),
-            _CenterTitleSwitch(),
+            _SystemUiOverlayStyleDropdown(),
             _ElevationTextField(),
+            _CenterTitleSwitch(),
             _TitleSpacingTextField(),
+            _ToolBarHeightTextField(),
           ],
         ),
       ],
@@ -25,23 +28,75 @@ class AppBarEditor extends StatelessWidget {
   }
 }
 
-class _ColorPicker extends StatelessWidget {
+class _BackgroundColorPicker extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<AdvancedThemeCubit, AdvancedThemeState>(
       buildWhen: (previous, current) {
-        return previous.themeData.appBarTheme.color !=
-                current.themeData.appBarTheme.color ||
+        return previous.themeData.appBarTheme.backgroundColor !=
+                current.themeData.appBarTheme.backgroundColor ||
             previous.themeData.primaryColor != current.themeData.primaryColor;
       },
       builder: (context, state) {
         return ColorListTile(
-          key: const Key('appbarEditor_colorPicker'),
-          title: 'Color',
-          color:
-              state.themeData.appBarTheme.color ?? state.themeData.primaryColor,
+          key: const Key('appbarEditor_backgroundColorPicker'),
+          title: 'Background Color',
+          color: state.themeData.appBarTheme.backgroundColor ??
+              state.themeData.primaryColor,
           onColorChanged: (color) {
-            context.read<AdvancedThemeCubit>().appBarColorChanged(color);
+            context
+                .read<AdvancedThemeCubit>()
+                .appBarBackgroundColorChanged(color);
+          },
+        );
+      },
+    );
+  }
+}
+
+class _ForegroundColorPicker extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<AdvancedThemeCubit, AdvancedThemeState>(
+      buildWhen: (previous, current) {
+        return previous.themeData.appBarTheme.foregroundColor !=
+                current.themeData.appBarTheme.foregroundColor ||
+            previous.themeData.colorScheme.onPrimary !=
+                current.themeData.colorScheme.onPrimary;
+      },
+      builder: (context, state) {
+        return ColorListTile(
+          key: const Key('appbarEditor_foregroundColorPicker'),
+          title: 'Foreground Color',
+          color: state.themeData.appBarTheme.foregroundColor ??
+              state.themeData.colorScheme.onPrimary,
+          onColorChanged: (color) {
+            context
+                .read<AdvancedThemeCubit>()
+                .appBarForegroundColorChanged(color);
+          },
+        );
+      },
+    );
+  }
+}
+
+class _ElevationTextField extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<AdvancedThemeCubit, AdvancedThemeState>(
+      buildWhen: (previous, current) {
+        return previous.themeData.appBarTheme.elevation !=
+            current.themeData.appBarTheme.elevation;
+      },
+      builder: (context, state) {
+        return MyTextFormField(
+          key: const Key('appbarEditor_elevationTextField'),
+          labelText: 'Elevation',
+          initialValue: state.themeData.appBarTheme.elevation?.toString() ??
+              kAppBarElevation.toString(),
+          onChanged: (value) {
+            context.read<AdvancedThemeCubit>().appBarElevationChanged(value);
           },
         );
       },
@@ -73,32 +128,6 @@ class _ShadowColorPicker extends StatelessWidget {
   }
 }
 
-class _BrightnessSwitch extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return BlocBuilder<AdvancedThemeCubit, AdvancedThemeState>(
-      buildWhen: (previous, current) {
-        return previous.themeData.appBarTheme.brightness !=
-            current.themeData.appBarTheme.brightness;
-      },
-      builder: (context, state) {
-        final isDark =
-            state.themeData.appBarTheme.brightness == Brightness.dark;
-
-        return MySwitchListTile(
-          key: const Key('appbarEditor_brightnessSwitch'),
-          title: 'Brightness',
-          value: isDark,
-          onChanged: (value) {
-            context.read<AdvancedThemeCubit>().appBarBrightnessChanged(value);
-          },
-          label: 'Dark',
-        );
-      },
-    );
-  }
-}
-
 class _CenterTitleSwitch extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
@@ -114,29 +143,6 @@ class _CenterTitleSwitch extends StatelessWidget {
           value: state.themeData.appBarTheme.centerTitle ?? true,
           onChanged: (value) {
             context.read<AdvancedThemeCubit>().appBarCenterTitleChanged(value);
-          },
-        );
-      },
-    );
-  }
-}
-
-class _ElevationTextField extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return BlocBuilder<AdvancedThemeCubit, AdvancedThemeState>(
-      buildWhen: (previous, current) {
-        return previous.themeData.appBarTheme.elevation !=
-            current.themeData.appBarTheme.elevation;
-      },
-      builder: (context, state) {
-        return MyTextFormField(
-          key: const Key('appbarEditor_elevationTextField'),
-          labelText: 'Elevation',
-          initialValue: state.themeData.appBarTheme.elevation?.toString() ??
-              kAppBarElevation.toString(),
-          onChanged: (value) {
-            context.read<AdvancedThemeCubit>().appBarElevationChanged(value);
           },
         );
       },
@@ -160,6 +166,57 @@ class _TitleSpacingTextField extends StatelessWidget {
               kAppBarTitleSpacing.toString(),
           onChanged: (value) {
             context.read<AdvancedThemeCubit>().appBarTitleSpacingChanged(value);
+          },
+        );
+      },
+    );
+  }
+}
+
+class _ToolBarHeightTextField extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<AdvancedThemeCubit, AdvancedThemeState>(
+      buildWhen: (previous, current) {
+        return previous.themeData.appBarTheme.toolbarHeight !=
+            current.themeData.appBarTheme.toolbarHeight;
+      },
+      builder: (context, state) {
+        return MyTextFormField(
+          key: const Key('appbarEditor_toolBarHeightTextField'),
+          labelText: 'Tool Bar Height',
+          initialValue: state.themeData.appBarTheme.toolbarHeight?.toString() ??
+              kToolbarHeight.toString(),
+          onChanged: (value) {
+            context
+                .read<AdvancedThemeCubit>()
+                .appBarToolBarHeightChanged(value);
+          },
+        );
+      },
+    );
+  }
+}
+
+class _SystemUiOverlayStyleDropdown extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<AdvancedThemeCubit, AdvancedThemeState>(
+      buildWhen: (previous, current) {
+        return previous.themeData.appBarTheme.systemOverlayStyle !=
+            current.themeData.appBarTheme.systemOverlayStyle;
+      },
+      builder: (context, state) {
+        return DropdownListTile(
+          title: 'System UI Overlay Style',
+          value: MySystemUiOverlayStyle().stringFromEnum(
+                  state.themeData.appBarTheme.systemOverlayStyle) ??
+              'Light',
+          values: MySystemUiOverlayStyle().names,
+          onChanged: (value) {
+            context
+                .read<AdvancedThemeCubit>()
+                .appBarSystemUiOverlayStyleChanged(value!);
           },
         );
       },

--- a/lib/advanced_theme/views/color_editor.dart
+++ b/lib/advanced_theme/views/color_editor.dart
@@ -14,7 +14,6 @@ class ColorEditor extends StatelessWidget {
           left: _PrimaryColorLightPicker(),
           right: _PrimaryColorDarkPicker(),
         ),
-        _AccentColorPicker(),
         SideBySideList(
           children: [
             _BackgroundColorPicker(),
@@ -111,35 +110,6 @@ class _PrimaryColorDarkPicker extends StatelessWidget {
           color: state.themeData.primaryColorDark,
           onColorChanged: (color) {
             context.read<AdvancedThemeCubit>().primaryColorDarkChanged(color);
-          },
-        );
-      },
-    );
-  }
-}
-
-class _AccentColorPicker extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return BlocBuilder<AdvancedThemeCubit, AdvancedThemeState>(
-      buildWhen: (previous, current) {
-        return previous.themeData.accentColor !=
-                current.themeData.accentColor ||
-            previous.themeData.accentColorBrightness !=
-                current.themeData.accentColorBrightness;
-      },
-      builder: (context, state) {
-        return ColorAndBrightness(
-          title: 'Accent Color',
-          color: state.themeData.accentColor,
-          onColorChanged: (color) {
-            context.read<AdvancedThemeCubit>().accentColorChanged(color);
-          },
-          isColorDark: state.isAccentColorDark,
-          onBrightnessChanged: (isDark) {
-            context
-                .read<AdvancedThemeCubit>()
-                .accentColorBrightnessChanged(isDark);
           },
         );
       },

--- a/lib/home/views/home_page.dart
+++ b/lib/home/views/home_page.dart
@@ -24,7 +24,7 @@ class HomePage extends StatefulWidget {
 }
 
 class _HomePageState extends State<HomePage> {
-  static const _sdkVersion = '2.2.3';
+  static const _sdkVersion = '2.5.1';
   @override
   void initState() {
     super.initState();

--- a/lib/models/enums/enums.dart
+++ b/lib/models/enums/enums.dart
@@ -1,2 +1,3 @@
 export 'font_weight.dart';
 export 'text_decoration.dart';
+export 'system_ui_overlay_style.dart';

--- a/lib/models/enums/system_ui_overlay_style.dart
+++ b/lib/models/enums/system_ui_overlay_style.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_theme/models/enums/enum_model.dart';
+
+class MySystemUiOverlayStyle extends EnumModel<SystemUiOverlayStyle> {
+  static const Map<String, SystemUiOverlayStyle> _values = {
+    'Light': SystemUiOverlayStyle.light,
+    'Dark': SystemUiOverlayStyle.dark,
+  };
+
+  MySystemUiOverlayStyle() : super(_values);
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.1"
+    version: "1.7.2"
   args:
     dependency: transitive
     description:
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.1"
   bloc:
     dependency: "direct main"
     description:
@@ -119,7 +119,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -224,7 +224,7 @@ packages:
       name: device_preview
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.4"
   dio:
     dependency: "direct main"
     description:
@@ -545,7 +545,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   mime:
     dependency: transitive
     description:
@@ -977,21 +977,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.8"
+    version: "1.17.10"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.2"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.19"
+    version: "0.4.0"
   timing:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   bloc: ^7.0.0
   copy_with_extension: ^2.0.0
   cupertino_icons: ^1.0.0
-  device_preview: ^0.7.3
+  device_preview: ^0.7.4
   dio: ^4.0.0
   enum_to_string: ^2.0.1
   equatable: ^2.0.0

--- a/test/advanced_theme/cubit/app_bar_cubit_test.dart
+++ b/test/advanced_theme/cubit/app_bar_cubit_test.dart
@@ -4,8 +4,8 @@ import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_theme/advanced_theme/advanced_theme.dart';
+import 'package:flutter_theme/models/models.dart';
 
-import '../../brightness.dart';
 import '../../utils.dart';
 
 void main() {
@@ -15,15 +15,41 @@ void main() {
     cubit = AdvancedThemeCubit();
   });
 
-  group('appBarColorChanged', () {
+  group('appBarBackgroundColorChanged', () {
     final color = getRandomColor();
-    final appBarTheme = AppBarTheme(color: color);
+    final appBarTheme = AppBarTheme(backgroundColor: color);
     final theme = ThemeData(appBarTheme: appBarTheme);
 
     blocTest<AdvancedThemeCubit, AdvancedThemeState>(
-      'emits app bar color',
+      'should emit app bar background color',
       build: () => cubit,
-      act: (cubit) => cubit.appBarColorChanged(color),
+      act: (cubit) => cubit.appBarBackgroundColorChanged(color),
+      expect: () => [AdvancedThemeState(themeData: theme)],
+    );
+  });
+
+  group('appBarForegroundColorChanged', () {
+    final color = getRandomColor();
+    final appBarTheme = AppBarTheme(foregroundColor: color);
+    final theme = ThemeData(appBarTheme: appBarTheme);
+
+    blocTest<AdvancedThemeCubit, AdvancedThemeState>(
+      'should emit app bar foreground color',
+      build: () => cubit,
+      act: (cubit) => cubit.appBarForegroundColorChanged(color),
+      expect: () => [AdvancedThemeState(themeData: theme)],
+    );
+  });
+
+  group('appBarElevationChanged', () {
+    final value = Random().nextDouble();
+    final appBarTheme = AppBarTheme(elevation: value);
+    final theme = ThemeData(appBarTheme: appBarTheme);
+
+    blocTest<AdvancedThemeCubit, AdvancedThemeState>(
+      'should emit app bar elevation',
+      build: () => cubit,
+      act: (cubit) => cubit.appBarElevationChanged(value.toString()),
       expect: () => [AdvancedThemeState(themeData: theme)],
     );
   });
@@ -34,25 +60,11 @@ void main() {
     final theme = ThemeData(appBarTheme: appBarTheme);
 
     blocTest<AdvancedThemeCubit, AdvancedThemeState>(
-      'emits app bar shadow color',
+      'should emit app bar shadow color',
       build: () => cubit,
       act: (cubit) => cubit.appBarShadowColorChanged(color),
       expect: () => [AdvancedThemeState(themeData: theme)],
     );
-  });
-
-  group('appBarBrightnessChanged', () {
-    for (var test in BrightnessTest.testCases) {
-      final appBarTheme = AppBarTheme(brightness: test.brightness);
-      final theme = ThemeData(appBarTheme: appBarTheme);
-
-      blocTest<AdvancedThemeCubit, AdvancedThemeState>(
-        'emits app bar ${test.brightness}',
-        build: () => cubit,
-        act: (cubit) => cubit.appBarBrightnessChanged(test.isDark),
-        expect: () => [AdvancedThemeState(themeData: theme)],
-      );
-    }
   });
 
   group('appBarCenterTitleChanged', () {
@@ -61,25 +73,12 @@ void main() {
       final theme = ThemeData(appBarTheme: appBarTheme);
 
       blocTest<AdvancedThemeCubit, AdvancedThemeState>(
-        'emits app bar centerTitle=$isCenter',
+        'should emit app bar centerTitle=$isCenter',
         build: () => cubit,
         act: (cubit) => cubit.appBarCenterTitleChanged(isCenter),
         expect: () => [AdvancedThemeState(themeData: theme)],
       );
     }
-  });
-
-  group('appBarElevationChanged', () {
-    final value = Random().nextDouble();
-    final appBarTheme = AppBarTheme(elevation: value);
-    final theme = ThemeData(appBarTheme: appBarTheme);
-
-    blocTest<AdvancedThemeCubit, AdvancedThemeState>(
-      'emits app bar elevation',
-      build: () => cubit,
-      act: (cubit) => cubit.appBarElevationChanged(value.toString()),
-      expect: () => [AdvancedThemeState(themeData: theme)],
-    );
   });
 
   group('appBarTitleSpacingChanged', () {
@@ -88,10 +87,41 @@ void main() {
     final theme = ThemeData(appBarTheme: appBarTheme);
 
     blocTest<AdvancedThemeCubit, AdvancedThemeState>(
-      'emits app bar title spacing',
+      'should emit app bar title spacing',
       build: () => cubit,
       act: (cubit) => cubit.appBarTitleSpacingChanged(value.toString()),
       expect: () => [AdvancedThemeState(themeData: theme)],
     );
+  });
+
+  group('appBarToolBarHeightChanged', () {
+    final value = Random().nextDouble();
+    final appBarTheme = AppBarTheme(toolbarHeight: value);
+    final theme = ThemeData(appBarTheme: appBarTheme);
+
+    blocTest<AdvancedThemeCubit, AdvancedThemeState>(
+      'should emit app bar tool bar height',
+      build: () => cubit,
+      act: (cubit) => cubit.appBarToolBarHeightChanged(value.toString()),
+      expect: () => [AdvancedThemeState(themeData: theme)],
+    );
+  });
+
+  group('appBarSystemUiOverlayStyleChanged', () {
+    for (var style in MySystemUiOverlayStyle().values) {
+      final appBarTheme = AppBarTheme(systemOverlayStyle: style);
+      final theme = ThemeData(appBarTheme: appBarTheme);
+
+      blocTest<AdvancedThemeCubit, AdvancedThemeState>(
+        'should emit app bar ${style.statusBarBrightness}',
+        build: () => cubit,
+        act: (cubit) {
+          cubit.appBarSystemUiOverlayStyleChanged(
+            MySystemUiOverlayStyle().stringFromEnum(style)!,
+          );
+        },
+        expect: () => [AdvancedThemeState(themeData: theme)],
+      );
+    }
   });
 }

--- a/test/advanced_theme/cubit/color_cubit_test.dart
+++ b/test/advanced_theme/cubit/color_cubit_test.dart
@@ -50,34 +50,6 @@ void main() {
     );
   });
 
-  // group('accentColorChanged', () {
-  //   final color = getRandomColor();
-  //   final theme = ThemeData(
-  //     accentColor: color,
-  //     accentColorBrightness: ThemeData.estimateBrightnessForColor(color),
-  //   );
-
-  //   blocTest<AdvancedThemeCubit, AdvancedThemeState>(
-  //     'emits accent color',
-  //     build: () => cubit,
-  //     act: (cubit) => cubit.accentColorChanged(color),
-  //     expect: () => [AdvancedThemeState(themeData: theme)],
-  //   );
-  // });
-
-  group('accentColorBrightnessChanged', () {
-    for (var test in BrightnessTest.testCases) {
-      final theme = ThemeData(accentColorBrightness: test.brightness);
-
-      blocTest<AdvancedThemeCubit, AdvancedThemeState>(
-        'emits accent color ${test.brightness}',
-        build: () => cubit,
-        act: (cubit) => cubit.accentColorBrightnessChanged(test.isDark),
-        expect: () => [AdvancedThemeState(themeData: theme)],
-      );
-    }
-  });
-
   group('bgColorChanged', () {
     final color = getRandomColor();
     final theme = ThemeData(backgroundColor: color);

--- a/test/advanced_theme/views/app_bar_editor_test.dart
+++ b/test/advanced_theme/views/app_bar_editor_test.dart
@@ -6,7 +6,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_theme/advanced_theme/advanced_theme.dart';
 import 'package:mocktail/mocktail.dart';
 
-import '../../brightness.dart';
 import '../../pump_app.dart';
 import '../../utils.dart';
 import '../../widget_testers.dart';
@@ -38,18 +37,18 @@ void main() {
     await tester.pumpApp(AppBarEditor(), advancedThemeCubit: cubit);
   }
 
-  testWidgets('displays AppBarEditor', (tester) async {
+  testWidgets('should display AppBarEditor', (tester) async {
     await tester.pumpApp(AppBarEditor(), advancedThemeCubit: cubit);
     expect(find.byType(AppBarEditor), findsOneWidget);
   });
 
   testWidgets(
-    'color picker should update with selected color',
+    'background color picker should update with selected color',
     (tester) async {
       final color = getRandomColor();
       final state = AdvancedThemeState(
         themeData: ThemeData(
-          appBarTheme: AppBarTheme(color: color),
+          appBarTheme: AppBarTheme(backgroundColor: color),
         ),
       );
 
@@ -57,8 +56,50 @@ void main() {
 
       await widgetTesters.checkColorPicker(
         tester,
-        'appbarEditor_colorPicker',
+        'appbarEditor_backgroundColorPicker',
         color,
+      );
+      verify(() => cubit.emit(state)).called(1);
+    },
+  );
+
+  testWidgets(
+    'foreground color picker should update with selected color',
+    (tester) async {
+      final color = getRandomColor();
+      final state = AdvancedThemeState(
+        themeData: ThemeData(
+          appBarTheme: AppBarTheme(foregroundColor: color),
+        ),
+      );
+
+      await _pumpApp(tester, state);
+
+      await widgetTesters.checkColorPicker(
+        tester,
+        'appbarEditor_foregroundColorPicker',
+        color,
+      );
+      verify(() => cubit.emit(state)).called(1);
+    },
+  );
+
+  testWidgets(
+    'elevation should update with value',
+    (tester) async {
+      final value = Random().nextDouble();
+      final state = AdvancedThemeState(
+        themeData: ThemeData(
+          appBarTheme: AppBarTheme(elevation: value),
+        ),
+      );
+
+      await _pumpApp(tester, state);
+
+      await widgetTesters.checkTextField(
+        tester,
+        'appbarEditor_elevationTextField',
+        value,
       );
       verify(() => cubit.emit(state)).called(1);
     },
@@ -85,81 +126,35 @@ void main() {
     },
   );
 
-  for (var test in BrightnessTest.testCases) {
-    testWidgets(
-      'brightness should be toggled to ${test.isDark}',
-      (tester) async {
-        final state = AdvancedThemeState(
-          themeData: ThemeData(
-            appBarTheme: AppBarTheme(brightness: test.brightness),
-          ),
-        );
+  group('test center title', () {
+    for (var isCenter in [true, false]) {
+      testWidgets(
+        'center title should be toggled to $isCenter',
+        (tester) async {
+          final state = AdvancedThemeState(
+            themeData: ThemeData(
+              appBarTheme: AppBarTheme(centerTitle: isCenter),
+            ),
+          );
 
-        await _pumpApp(tester, state);
+          await _pumpApp(tester, state);
 
-        await widgetTesters.checkSwitch(
-          tester,
-          'appbarEditor_brightnessSwitch',
-          test.isDark,
-        );
-        final expectedState = AdvancedThemeState(
-          themeData: ThemeData(
-            appBarTheme: AppBarTheme(brightness: test.brightnessComplement),
-          ),
-        );
-        verify(() => cubit.emit(expectedState)).called(1);
-      },
-    );
-  }
+          await widgetTesters.checkSwitch(
+            tester,
+            'appbarEditor_centerTitleSwitch',
+            isCenter,
+          );
 
-  for (var isCenter in [true, false]) {
-    testWidgets(
-      'center title should be toggled to $isCenter',
-      (tester) async {
-        final state = AdvancedThemeState(
-          themeData: ThemeData(
-            appBarTheme: AppBarTheme(centerTitle: isCenter),
-          ),
-        );
-
-        await _pumpApp(tester, state);
-
-        await widgetTesters.checkSwitch(
-          tester,
-          'appbarEditor_centerTitleSwitch',
-          isCenter,
-        );
-
-        final expectedState = AdvancedThemeState(
-          themeData: ThemeData(
-            appBarTheme: AppBarTheme(centerTitle: !isCenter),
-          ),
-        );
-        verify(() => cubit.emit(expectedState)).called(1);
-      },
-    );
-  }
-
-  testWidgets(
-    'elevation should update with value',
-    (tester) async {
-      final value = Random().nextDouble();
-      final state = AdvancedThemeState(
-        themeData: ThemeData(
-          appBarTheme: AppBarTheme(elevation: value),
-        ),
+          final expectedState = AdvancedThemeState(
+            themeData: ThemeData(
+              appBarTheme: AppBarTheme(centerTitle: !isCenter),
+            ),
+          );
+          verify(() => cubit.emit(expectedState)).called(1);
+        },
       );
-
-      await _pumpApp(tester, state);
-
-      await widgetTesters.checkTextField(
-        tester,
-        'appbarEditor_elevationTextField',
-        value,
-      );
-      verify(() => cubit.emit(state)).called(1);
-    },
-  );
+    }
+  });
 
   testWidgets(
     'title spacing should update with value',
@@ -176,6 +171,27 @@ void main() {
       await widgetTesters.checkTextField(
         tester,
         'appbarEditor_titleSpacingTextField',
+        value,
+      );
+      verify(() => cubit.emit(state)).called(1);
+    },
+  );
+
+  testWidgets(
+    'tool bar height should update with value',
+    (tester) async {
+      final value = Random().nextDouble();
+      final state = AdvancedThemeState(
+        themeData: ThemeData(
+          appBarTheme: AppBarTheme(toolbarHeight: value),
+        ),
+      );
+
+      await _pumpApp(tester, state);
+
+      await widgetTesters.checkTextField(
+        tester,
+        'appbarEditor_toolBarHeightTextField',
         value,
       );
       verify(() => cubit.emit(state)).called(1);


### PR DESCRIPTION
- Bump Flutter SDK to `2.5.1`
- Remove deprecated theme data properties
- Update app bar theme data properties to latest
- Bump `device_preview` to `0.7.4` to fix package name conflict