### PR TITLE
feat: bump flutter sdk to 2.5.1

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,4 +1,4 @@
 {
-  "flutterSdkVersion": "2.2.3",
+  "flutterSdkVersion": "2.5.1",
   "flavors": {}
 }

--- a/.github/workflows/test_deploy_release.yml
+++ b/.github/workflows/test_deploy_release.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
 
 env:
-  flutter-version: 2.2.3
+  flutter-version: 2.5.1
 
 jobs:
   test:

--- a/lib/home/views/home_page.dart
+++ b/lib/home/views/home_page.dart
@@ -23,7 +23,7 @@ class HomePage extends StatefulWidget {
 }
 
 class _HomePageState extends State<HomePage> {
-  static const _sdkVersion = '2.2.3';
+  static const _sdkVersion = '2.5.1';
 
   @override
   void initState() {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.1"
+    version: "1.7.2"
   args:
     dependency: transitive
     description:
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.1"
   bloc:
     dependency: "direct main"
     description:
@@ -119,7 +119,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -224,7 +224,7 @@ packages:
       name: device_preview
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.4"
   dio:
     dependency: "direct main"
     description:
@@ -545,7 +545,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   mime:
     dependency: transitive
     description:
@@ -970,21 +970,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.8"
+    version: "1.17.10"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.2"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.19"
+    version: "0.4.0"
   timing:
     dependency: transitive
     description:


### PR DESCRIPTION
- Bump Flutter SDK to `2.5.1`
- Remove deprecated theme data properties
- Update app bar theme data properties to latest
- Bump `device_preview` to `0.7.4` to fix package name conflict