### PR TITLE
fix: remove focus color in input decoration editor

### DIFF
--- a/lib/advanced_theme/cubit/input_decoration_cubit.dart
+++ b/lib/advanced_theme/cubit/input_decoration_cubit.dart
@@ -24,13 +24,6 @@ extension InputDecorationCubit on AdvancedThemeCubit {
     _emitStateWithIconTheme(theme);
   }
 
-  void inputDecorationFocusColorChanged(Color color) {
-    final theme = state.themeData.inputDecorationTheme.copyWith(
-      focusColor: color,
-    );
-    _emitStateWithIconTheme(theme);
-  }
-
   void inputDecorationHoverColorChanged(Color color) {
     final theme = state.themeData.inputDecorationTheme.copyWith(
       hoverColor: color,

--- a/lib/advanced_theme/views/input_decoration_editor.dart
+++ b/lib/advanced_theme/views/input_decoration_editor.dart
@@ -18,7 +18,6 @@ class InputDecorationEditor extends ExpansionPanelItem {
       children: [
         _FloatingLabelBehaviorDropdown(),
         _FillColorPicker(),
-        _FocusColorPicker(),
         _HoverColorPicker(),
         _AlignLabelWithHintSwitch(),
         _FilledSwitch(),
@@ -76,31 +75,6 @@ class _FillColorPicker extends StatelessWidget {
             context
                 .read<AdvancedThemeCubit>()
                 .inputDecorationFillColorChanged(color);
-          },
-        );
-      },
-    );
-  }
-}
-
-class _FocusColorPicker extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return BlocBuilder<AdvancedThemeCubit, AdvancedThemeState>(
-      buildWhen: (previous, current) {
-        return previous.themeData.inputDecorationTheme.focusColor !=
-            current.themeData.inputDecorationTheme.focusColor;
-      },
-      builder: (context, state) {
-        return ColorListTile(
-          key: const Key('inputDecorationEditor_focusColorPicker'),
-          title: 'Focus Color',
-          color: state.themeData.inputDecorationTheme.focusColor ??
-              state.themeData.focusColor,
-          onColorChanged: (color) {
-            context
-                .read<AdvancedThemeCubit>()
-                .inputDecorationFocusColorChanged(color);
           },
         );
       },

--- a/test/advanced_theme/cubit/input_decoration_cubit_test.dart
+++ b/test/advanced_theme/cubit/input_decoration_cubit_test.dart
@@ -52,22 +52,6 @@ void main() {
     );
   });
 
-  group('inputDecorationFocusColorChanged', () {
-    final color = getRandomColor();
-    final theme = ThemeData(
-      inputDecorationTheme: InputDecorationTheme(
-        focusColor: color,
-      ),
-    );
-
-    blocTest<AdvancedThemeCubit, AdvancedThemeState>(
-      'emits input decoration focus color',
-      build: () => cubit,
-      act: (cubit) => cubit.inputDecorationFocusColorChanged(color),
-      expect: () => [AdvancedThemeState(themeData: theme)],
-    );
-  });
-
   group('inputDecorationHoverColorChanged', () {
     final color = getRandomColor();
     final theme = ThemeData(

--- a/test/advanced_theme/views/input_decoration_editor_test.dart
+++ b/test/advanced_theme/views/input_decoration_editor_test.dart
@@ -61,27 +61,6 @@ void main() {
   );
 
   testWidgets(
-    'focus color picker should update with color',
-    (tester) async {
-      final color = getRandomColor();
-      final state = AdvancedThemeState(
-        themeData: ThemeData(
-          inputDecorationTheme: InputDecorationTheme(focusColor: color),
-        ),
-      );
-
-      await _pumpApp(tester, state);
-
-      await widgetTesters.checkColorPicker(
-        tester,
-        'inputDecorationEditor_focusColorPicker',
-        color,
-      );
-      verify(() => cubit.emit(state)).called(1);
-    },
-  );
-
-  testWidgets(
     'hover color picker should update with color',
     (tester) async {
       final color = getRandomColor();


### PR DESCRIPTION
- Focus color is not being used in `InputDecoration` https://github.com/flutter/flutter/issues/50866
- Removing focus color option from input decoration editor
- Related issue: #166 