### PR TITLE
fix: disable opacity for primary color pickers

### DIFF
--- a/lib/basic_theme/views/basic_editor.dart
+++ b/lib/basic_theme/views/basic_editor.dart
@@ -36,6 +36,7 @@ class _PrimaryColorPicker extends StatelessWidget {
       builder: (context, state) {
         return ColorBrightnessListTile(
           key: const Key('basicEditor_primaryColorPicker'),
+          enableOpacity: false,
           title: 'Primary Color',
           color: state.colorScheme.primary,
           onColorChanged: (color) {

--- a/lib/color_theme/view/color_theme_editor.dart
+++ b/lib/color_theme/view/color_theme_editor.dart
@@ -55,8 +55,9 @@ class _PrimaryColorPicker extends StatelessWidget {
       },
       builder: (context, state) {
         return ColorBrightnessListTile(
-          title: 'Primary Color',
           key: const Key('colorThemeEditor_primaryColorPicker'),
+          enableOpacity: false,
+          title: 'Primary Color',
           color: state.primaryColor,
           onColorChanged: (color) {
             context.read<ColorThemeCubit>().primaryColorChanged(color);

--- a/lib/services/widget_service.dart
+++ b/lib/services/widget_service.dart
@@ -6,6 +6,7 @@ class WidgetService {
     required BuildContext context,
     required Color color,
     required ValueChanged<Color> onColorChanged,
+    bool enableOpacity = true,
   }) async {
     ColorPicker(
       key: const Key('widgetService_showColorPicker'),
@@ -14,7 +15,7 @@ class WidgetService {
       showMaterialName: true,
       showColorCode: true,
       showColorName: true,
-      enableOpacity: true,
+      enableOpacity: enableOpacity,
       onColorChanged: onColorChanged,
       heading: Text(
         'Select color',

--- a/lib/widgets/list_tiles/color_brightness_list_tile.dart
+++ b/lib/widgets/list_tiles/color_brightness_list_tile.dart
@@ -8,6 +8,7 @@ class ColorBrightnessListTile extends StatelessWidget {
   final void Function(Color) onColorChanged;
   final bool isColorDark;
   final void Function(bool) onBrightnessChanged;
+  final bool enableOpacity;
 
   const ColorBrightnessListTile({
     Key? key,
@@ -16,6 +17,7 @@ class ColorBrightnessListTile extends StatelessWidget {
     required this.onColorChanged,
     required this.isColorDark,
     required this.onBrightnessChanged,
+    this.enableOpacity = true,
   }) : super(key: key);
 
   @override
@@ -28,6 +30,7 @@ class ColorBrightnessListTile extends StatelessWidget {
               title: title,
               color: color,
               onColorChanged: onColorChanged,
+              enableOpacity: enableOpacity,
             ),
           ),
           const VerticalDivider(),

--- a/lib/widgets/list_tiles/color_list_tile.dart
+++ b/lib/widgets/list_tiles/color_list_tile.dart
@@ -8,12 +8,14 @@ class ColorListTile extends StatelessWidget {
   final String title;
   final Color color;
   final void Function(Color) onColorChanged;
+  final bool enableOpacity;
 
   const ColorListTile({
     Key? key,
     required this.title,
     required this.color,
     required this.onColorChanged,
+    this.enableOpacity = true,
   }) : super(key: key);
 
   @override
@@ -31,6 +33,7 @@ class ColorListTile extends StatelessWidget {
           context: context,
           color: color,
           onColorChanged: onColorChanged,
+          enableOpacity: enableOpacity,
         ),
       ),
     );

--- a/test/basic_theme/basic_theme_editor_test.dart
+++ b/test/basic_theme/basic_theme_editor_test.dart
@@ -1,64 +1,58 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_theme/basic_theme/cubit/basic_theme_cubit.dart';
 import 'package:flutter_theme/basic_theme/views/basic_editor.dart';
 import 'package:mocktail/mocktail.dart';
 
-import '../../brightness.dart';
-import '../../pump_app.dart';
-import '../../utils.dart';
-import '../../widget_testers.dart';
-
-class MockBasicThemeCubit extends MockCubit<BasicThemeState>
-    implements BasicThemeCubit {}
-
-class FakeBasicThemeState extends Fake implements BasicThemeState {}
+import '../brightness.dart';
+import '../mocks.dart';
+import '../pump_app.dart';
+import '../utils.dart';
+import '../widget_testers.dart';
 
 void main() {
   final widgetTesters = WidgetTesters();
-  late BasicThemeCubit cubit;
 
-  setUpAll(() {
-    registerFallbackValue(FakeBasicThemeState());
-  });
+  late BasicThemeCubit cubit;
+  late Color color;
 
   setUp(() {
     cubit = MockBasicThemeCubit();
-    when(() => cubit.state).thenReturn(const BasicThemeState());
+    color = getRandomColor();
   });
 
   Future<void> _pumpApp(WidgetTester tester, ColorScheme colorScheme) async {
     whenListen(
       cubit,
-      Stream.fromIterable([
-        const BasicThemeState(),
-        BasicThemeState(colorScheme: colorScheme),
-      ]),
+      Stream.fromIterable([BasicThemeState(colorScheme: colorScheme)]),
+      initialState: const BasicThemeState(),
+    );
+
+    await tester.pumpWidget(
+      BlocProvider.value(
+        value: cubit,
+        child: const MaterialApp(
+          home: BasicEditor(),
+        ),
+      ),
     );
 
     await tester.pumpApp(const BasicEditor(), basicThemeCubit: cubit);
   }
 
-  testWidgets('displays BasicEditor', (tester) async {
-    await tester.pumpApp(const BasicEditor(), basicThemeCubit: cubit);
-    expect(find.byType(BasicEditor), findsOneWidget);
-  });
-
-  group('primary color picker', () {
+  group('test primary color', () {
     const key = 'basicEditor_primaryColorPicker';
 
     testWidgets(
       'color picker should update with selected color',
       (tester) async {
-        // Given
-        final color = getRandomColor();
+        color = const Color(0xFFF44336);
         final colorScheme = ColorScheme.light(primary: color);
 
-        // When
         await _pumpApp(tester, colorScheme);
 
-        // Then
         await widgetTesters.checkColorPicker(tester, key, color);
         verify(() => cubit.primaryColorChanged(color)).called(1);
       },
@@ -68,28 +62,23 @@ void main() {
       testWidgets(
         'brightness switch should be toggled with ${test.isDark}',
         (tester) async {
-          // Given
           final colorScheme = ColorScheme.light(onPrimary: test.color);
 
-          // When
           await _pumpApp(tester, colorScheme);
 
-          // Then
           await widgetTesters.checkSwitch(tester, key, test.isDark);
-          verify(() {
-            cubit.primaryColorBrightnessChanged(!test.isDark);
-          }).called(1);
+          verify(
+            () => cubit.primaryColorBrightnessChanged(!test.isDark),
+          ).called(1);
         },
       );
     }
   });
 
-  group('primary color dark picker', () {
+  group('test primary color dark', () {
     testWidgets(
       'color picker should update with selected color',
       (tester) async {
-        // Given
-        final color = getRandomColor();
         final colorScheme = ColorScheme.light(primaryVariant: color);
 
         // When
@@ -106,20 +95,16 @@ void main() {
     );
   });
 
-  group('secondary color picker', () {
+  group('test secondary color', () {
     const key = 'basicEditor_secondaryColorPicker';
 
     testWidgets(
       'color picker should update with selected color',
       (tester) async {
-        // Given
-        final color = getRandomColor();
         final colorScheme = ColorScheme.light(secondary: color);
 
-        // When
         await _pumpApp(tester, colorScheme);
 
-        // Then
         await widgetTesters.checkColorPicker(tester, key, color);
         verify(() => cubit.secondaryColorChanged(color)).called(1);
       },
@@ -129,34 +114,27 @@ void main() {
       testWidgets(
         'brightness switch should be toggled with ${test.isDark}',
         (tester) async {
-          // Given
           final colorScheme = ColorScheme.light(onSecondary: test.color);
 
-          // When
           await _pumpApp(tester, colorScheme);
 
-          // Then
           await widgetTesters.checkSwitch(tester, key, test.isDark);
-          verify(() {
-            cubit.secondaryColorBrightnessChanged(!test.isDark);
-          }).called(1);
+          verify(
+            () => cubit.secondaryColorBrightnessChanged(!test.isDark),
+          ).called(1);
         },
       );
     }
   });
 
-  group('secondary color dark picker', () {
+  group('test secondary color dark', () {
     testWidgets(
       'color picker should update with selected color',
       (tester) async {
-        // Given
-        final color = getRandomColor();
         final colorScheme = ColorScheme.light(secondaryVariant: color);
 
-        // When
         await _pumpApp(tester, colorScheme);
 
-        // Then
         await widgetTesters.checkColorPicker(
           tester,
           'basicEditor_secondaryColorDarkPicker',
@@ -167,20 +145,16 @@ void main() {
     );
   });
 
-  group('surface color picker', () {
+  group('test surface color', () {
     const key = 'basicEditor_surfaceColorPicker';
 
     testWidgets(
       'color picker should update with selected color',
       (tester) async {
-        // Given
-        final color = getRandomColor();
         final colorScheme = ColorScheme.light(surface: color);
 
-        // When
         await _pumpApp(tester, colorScheme);
 
-        // Then
         await widgetTesters.checkColorPicker(tester, key, color);
         verify(() => cubit.surfaceColorChanged(color)).called(1);
       },
@@ -190,36 +164,29 @@ void main() {
       testWidgets(
         'brightness switch should be toggled with ${test.isDark}',
         (tester) async {
-          // Given
           final colorScheme = ColorScheme.light(onSurface: test.color);
 
-          // When
           await _pumpApp(tester, colorScheme);
 
-          // Then
           await widgetTesters.checkSwitch(tester, key, test.isDark);
-          verify(() {
-            cubit.surfaceColorBrightnessChanged(!test.isDark);
-          }).called(1);
+          verify(
+            () => cubit.surfaceColorBrightnessChanged(!test.isDark),
+          ).called(1);
         },
       );
     }
   });
 
-  group('background color picker', () {
+  group('test background color', () {
     const key = 'basicEditor_backgroundColorPicker';
 
     testWidgets(
       'color picker should update with selected color',
       (tester) async {
-        // Given
-        final color = getRandomColor();
         final colorScheme = ColorScheme.light(background: color);
 
-        // When
         await _pumpApp(tester, colorScheme);
 
-        // Then
         await widgetTesters.checkColorPicker(tester, key, color);
         verify(() => cubit.backgroundColorChanged(color)).called(1);
       },
@@ -229,36 +196,29 @@ void main() {
       testWidgets(
         'brightness switch should be toggled with ${test.isDark}',
         (tester) async {
-          // Given
           final colorScheme = ColorScheme.light(onBackground: test.color);
 
-          // When
           await _pumpApp(tester, colorScheme);
 
-          // Then
           await widgetTesters.checkSwitch(tester, key, test.isDark);
-          verify(() {
-            cubit.backgroundColorBrightnessChanged(!test.isDark);
-          }).called(1);
+          verify(
+            () => cubit.backgroundColorBrightnessChanged(!test.isDark),
+          ).called(1);
         },
       );
     }
   });
 
-  group('error color picker', () {
+  group('test error color', () {
     const key = 'basicEditor_errorColorPicker';
 
     testWidgets(
       'color picker should update with selected color',
       (tester) async {
-        // Given
-        final color = getRandomColor();
         final colorScheme = ColorScheme.light(error: color);
 
-        // When
         await _pumpApp(tester, colorScheme);
 
-        // Then
         await widgetTesters.checkColorPicker(tester, key, color);
         verify(() => cubit.errorColorChanged(color)).called(1);
       },
@@ -268,17 +228,14 @@ void main() {
       testWidgets(
         'brightness switch should be toggled with ${test.isDark}',
         (tester) async {
-          // Given
           final colorScheme = ColorScheme.light(onError: test.color);
 
-          // When
           await _pumpApp(tester, colorScheme);
 
-          // Then
           await widgetTesters.checkSwitch(tester, key, test.isDark);
-          verify(() {
-            cubit.errorColorBrightnessChanged(!test.isDark);
-          }).called(1);
+          verify(
+            () => cubit.errorColorBrightnessChanged(!test.isDark),
+          ).called(1);
         },
       );
     }

--- a/test/color_theme/color_theme_editor_test.dart
+++ b/test/color_theme/color_theme_editor_test.dart
@@ -44,6 +44,7 @@ void main() {
     testWidgets(
       'color picker should update with selected color',
       (tester) async {
+        color = const Color(0xFFF44336);
         final state = ColorThemeState(primaryColor: color);
 
         await _pumpApp(tester, state);


### PR DESCRIPTION
- `ThemeData` doesn't allow primary colors that are not 100% opacity.
- Disable the opacity option for primary color pickers to address this